### PR TITLE
#2 Simplification of the Angel Block place logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-mod_version = 0.3.3
+mod_version = 0.3.4
 
 minecraft_version = 1.19
 minecraft_mapping_channel = official

--- a/src/main/java/me/siasur/unrelatedadditions/item/AngelBlockItem.java
+++ b/src/main/java/me/siasur/unrelatedadditions/item/AngelBlockItem.java
@@ -2,7 +2,6 @@ package me.siasur.unrelatedadditions.item;
 
 import me.siasur.unrelatedadditions.utils.VectorHelper;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -10,14 +9,19 @@ import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class AngelBlockItem extends BlockItem {
+
+    public static final String PLACEMENT_HINT_TOOLTIP_KEY = "tooltip.unrelatedadditions.angelblock_placement";
 
     public AngelBlockItem(Block block, Properties properties) {
         super(block, properties);
@@ -26,21 +30,17 @@ public class AngelBlockItem extends BlockItem {
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         ItemStack itemStack = player.getItemInHand(hand);
-        Vec3 viewVec = player.getViewVector(1);
-        Vec3 target = player.getEyePosition().add(viewVec);
-
-        // I absolutely hate this... But it works, so it's going to stay until I find a better way
-        while (player.getBoundingBox().intersects(new AABB(VectorHelper.floor(target), VectorHelper.floor(target).add(1, 1, 1))))
-        {
-            target = target.add(viewVec);
-        }
-
+        Vec3 target = player.getPosition(1).subtract(0, 1, 0);
         BlockPos position = VectorHelper.toBlockPos(target);
+
         BlockHitResult hitResult = new BlockHitResult(target, player.getDirection(), position, true);
         BlockPlaceContext placeContext = new BlockPlaceContext(level, null, hand, itemStack, hitResult);
-
         InteractionResult placeResult = this.place(placeContext);
-
         return new InteractionResultHolder(placeResult, itemStack);
+    }
+
+    @Override
+    public void appendHoverText(ItemStack itemStack, @Nullable Level level, List<Component> components, TooltipFlag tooltipFlag) {
+        components.add(Component.translatable(PLACEMENT_HINT_TOOLTIP_KEY));
     }
 }

--- a/src/main/resources/assets/unrelatedadditions/lang/en_us.json
+++ b/src/main/resources/assets/unrelatedadditions/lang/en_us.json
@@ -58,5 +58,6 @@
 
   "itemGroup.unrelatedadditions": "Unrelated Additions",
 
-  "tooltip.unrelatedadditions.compressedblock": "%s Blocks"
+  "tooltip.unrelatedadditions.compressedblock": "%s Blocks",
+  "tooltip.unrelatedadditions.angelblock_placement": "Can be placed into the air, will appear below you"
 }


### PR DESCRIPTION
Some testing showed me that starting at height 128, it'll lag even with the simplest `level.setBlock(position, ((BlockItem)itemStack.getItem()).getBlock().defaultBlockState(), Block.UPDATE_ALL_IMMEDIATE);` when the next block in a chunklike area around the place position is more than 16 blocks below.

As I can't make a place simpler than that, I'm going with "unfixable" for now. But I've improved it a bit. Side effect ist that I removed the fancy air placement instead it will always take the block below the player.